### PR TITLE
Fix inferring the crate name

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.82.0"
+components = ["rustfmt", "clippy"]
+profile = "minimal"


### PR DESCRIPTION
The old implementation assumed that we always have a top level crate, which cannot be assumed in general. We now reverse the path and try striping everything including `src`. Afterwards we assume that the directory on top of that is the parent crate name. That's still hacky, but works for our use-case. For a better solution we would query cargo-metadata for informations and then use that to resolve the crate names.