### PR TITLE
Toolchain update 1.86.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,9 +267,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustdoc-types"
-version = "0.32.2"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd5cb7a0c0a5a4f6bc429274fc1073d395237c83ef13d0ac728e0f95f5499ca"
+checksum = "e3b61d5673c3f4b49d35be6a58c49210596f61b8db580bc3b6d9dee5e9dc5458"
 dependencies = [
  "serde",
 ]

--- a/buffi/Cargo.toml
+++ b/buffi/Cargo.toml
@@ -15,4 +15,4 @@ serde = { version = "1.0.213", features = ["derive"] }
 serde_json = "1.0.132"
 serde-generate = { version = "0.26.0", default-features = false, features = ["cpp"] }
 serde-reflection = "0.4.0"
-rustdoc-types = "0.32.2"
+rustdoc-types = "0.39.0"

--- a/buffi/Cargo.toml
+++ b/buffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "buffi"
 description = "A tool to generate ergonomic, buffer-based C++ APIs."
-version = "0.2.6+rust.1.85.0"
+version = "0.2.7+rust.1.86.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/buffi"

--- a/buffi_macro/Cargo.toml
+++ b/buffi_macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "buffi_macro"
 description = "A proc-macro to generate ergonomic, buffer-based C++ APIs."
-version = "0.2.6"
+version = "0.2.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/buffi_macro"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.86.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
The usual toolchain update. This time, we had to update `rustdoc-types` as well, which renamed a field (name -> path), so I made the necessary changes. Otherwise the tests run again and everything seems in order when I used this update with our big codebase. So we should be fine. 👍 I have also reviewed the `rustdoc-types` update with diff.rs