### PR TITLE
Update to bincode 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,11 +49,22 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "1.3.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
+ "bincode_derive",
  "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
@@ -481,6 +492,18 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,18 +53,8 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
- "bincode_derive",
  "serde",
  "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
 ]
 
 [[package]]
@@ -498,12 +488,6 @@ name = "unty"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "buffi"
-version = "0.2.7+rust.1.86.0"
+version = "0.3.0+rust.1.86.0"
 dependencies = [
  "rustdoc-types",
  "serde",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "buffi_macro"
-version = "0.2.7"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -57,16 +57,25 @@ impl From<Box<dyn Any + Send>> for SerializableError {
     }
 }
 
-impl From<Box<bincode::ErrorKind>> for SerializableError {
-    fn from(value: Box<bincode::ErrorKind>) -> Self {
+impl From<bincode::error::DecodeError> for SerializableError {
+    fn from(value: bincode::error::DecodeError) -> Self {
         Self {
-            message: format!("Bincode: {value}"),
+            message: format!("Bincode Decode Error: {value}"),
         }
     }
 }
+
+impl From<bincode::error::EncodeError> for SerializableError {
+    fn from(value: bincode::error::EncodeError) -> Self {
+        Self {
+            message: format!("Bincode Encode Error: {value}"),
+        }
+    }
+}
+
 ```
 
-Note that the module, the error itself, and the fields on the error need to be public. If that is not the case, you should receive an error during code generation that points you to this issue. You will have to add [Serde](https://crates.io/crates/serde) and [Bincode](https://crates.io/crates/bincode) to your crate for this to work.
+Note that the module, the error itself, and the fields on the error need to be public. If that is not the case, you should receive an error during code generation that points you to this issue. You will have to add [Serde](https://crates.io/crates/serde) and [Bincode 2](https://crates.io/crates/bincode) to your crate for this to work.
 
 Furthermore, to release any memory allocated by the Rust side of your API, you will have to include a function for the C++ side to release memory. This function looks like this:
 

--- a/buffi/Cargo.toml
+++ b/buffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "buffi"
 description = "A tool to generate ergonomic, buffer-based C++ APIs."
-version = "0.2.7+rust.1.86.0"
+version = "0.3.0+rust.1.86.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/buffi"

--- a/buffi_macro/Cargo.toml
+++ b/buffi_macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "buffi_macro"
 description = "A proc-macro to generate ergonomic, buffer-based C++ APIs."
-version = "0.2.7"
+version = "0.3.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/buffi_macro"

--- a/buffi_macro/src/proc_macro.rs
+++ b/buffi_macro/src/proc_macro.rs
@@ -146,7 +146,7 @@ fn generate_exported_function<'a>(
                         std::slice::from_raw_parts(#n, #n_size)
                     }
                 };
-                let #n = bincode::deserialize(slice)?;
+                let #n = bincode::serde::decode_from_slice(slice, bincode::config::legacy())?.0;
             })
         } else {
             None
@@ -286,14 +286,14 @@ fn generate_exported_function<'a>(
                     Err(crate::errors::SerializableError::from(e))
                 }
             };
-            let bytes = match bincode::serialize(&res) {
+            let bytes = match bincode::serde::encode_to_vec(&res, bincode::config::legacy()) {
                 Ok(bytes) => {
                     bytes
                 }
                 Err(e) => {
                     #tracing_serializable_w
                     res = Err(e.into());
-                    match bincode::serialize(&res) {
+                    match bincode::serde::encode_to_vec(&res, bincode::config::legacy()) {
                         Ok(bytes) => {
                             bytes
                         }

--- a/example/buffi_example/Cargo.toml
+++ b/example/buffi_example/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 buffi_macro = { path = "../../buffi_macro" }
-bincode = { version = "2.0.1", features = ["serde"] }
+bincode = { version = "2.0.1", features = ["std", "serde"], default-features = false }
 serde = { version = "1.0.214", features = ["derive"] }
 tokio = { version = "1.41.1", features = ["rt-multi-thread"] }
 cgmath = { version = "0.18.0", features = ["serde"] }

--- a/example/buffi_example/Cargo.toml
+++ b/example/buffi_example/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 buffi_macro = { path = "../../buffi_macro" }
-bincode = "1.3.3"
+bincode = { version = "2.0.1", features = ["serde"] }
 serde = { version = "1.0.214", features = ["derive"] }
 tokio = { version = "1.41.1", features = ["rt-multi-thread"] }
 cgmath = { version = "0.18.0", features = ["serde"] }

--- a/example/buffi_example/src/errors.rs
+++ b/example/buffi_example/src/errors.rs
@@ -24,10 +24,18 @@ impl From<Box<dyn Any + Send>> for SerializableError {
     }
 }
 
-impl From<Box<bincode::ErrorKind>> for SerializableError {
-    fn from(value: Box<bincode::ErrorKind>) -> Self {
+impl From<bincode::error::DecodeError> for SerializableError {
+    fn from(value: bincode::error::DecodeError) -> Self {
         Self {
-            message: format!("Bincode: {value}"),
+            message: format!("Bincode Decode Error: {value}"),
+        }
+    }
+}
+
+impl From<bincode::error::EncodeError> for SerializableError {
+    fn from(value: bincode::error::EncodeError) -> Self {
+        Self {
+            message: format!("Bincode Encode Error: {value}"),
         }
     }
 }


### PR DESCRIPTION
This PR updates our proc-macro generated Rust code from `buffi_macro` to work with bincode 2. This is a breaking change and thus I've bumped the version to 0.3.0.

I've closely followed the [migration guide](https://docs.rs/bincode/latest/bincode/migration_guide/index.html) using the legacy configuration (I don't think we need it specifically, but it was the safe way to go) wherever necessary. Furthermore we will stick with `serde` for our `derive` needs. At this point more projects will already make use of `serde` and thus `buffi` is a bit more of a drop-in solution compared to `bincode`'s derive.

I have also reviewed the additional dependencies `unty` and `virtue`. I have yet to look through all the `bincode` changes going from 1.3.3 to 2.0.1.


- [x] https://diff.rs/unty/0.0.4/unty/0.0.4/Cargo.toml
- [x] https://diff.rs/virtue/0.0.18/virtue/0.0.18/Cargo.toml
- [x] https://diff.rs/bincode/1.3.3/2.0.1

## Migrating to buffi 0.3.0

For anyone using `buffi` you have to bump `bincode` to version 2 and add the `serde` feature flag. Furthermore `SerializableError` now needs to be derived for `DecodeError` and `EncodeError`. Check the readme or the example project for how this could look like.