### PR TITLE
Restructuring dependencies a bit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,8 @@ dependencies = [
 name = "buffi"
 version = "0.3.0+rust.1.86.0"
 dependencies = [
+ "bincode",
+ "buffi_macro",
  "rustdoc-types",
  "serde",
  "serde-generate",
@@ -83,8 +85,7 @@ dependencies = [
 name = "buffi_example"
 version = "0.1.0"
 dependencies = [
- "bincode",
- "buffi_macro",
+ "buffi",
  "cgmath",
  "serde",
  "tokio",

--- a/buffi/Cargo.toml
+++ b/buffi/Cargo.toml
@@ -10,9 +10,19 @@ keywords = ["FFI", "API", "C", "bincode", "serde"]
 categories = ["development-tools::ffi"]
 readme = "../README.md"
 
+[dependencies.buffi_macro]
+version = "=0.3.0"
+path = "../buffi_macro"
+
 [dependencies]
 serde = { version = "1.0.213", features = ["derive"] }
 serde_json = "1.0.132"
 serde-generate = { version = "0.26.0", default-features = false, features = ["cpp"] }
 serde-reflection = "0.4.0"
 rustdoc-types = "0.39.0"
+bincode = { version = "2.0.1", features = ["std", "serde"], default-features = false }
+
+[features]
+with_c_api = ["buffi_macro/with_c_api"]
+with_tracing = ["buffi_macro/with_tracing"]
+default = ["with_c_api"]

--- a/buffi/src/lib.rs
+++ b/buffi/src/lib.rs
@@ -33,6 +33,9 @@ use std::path::PathBuf;
 use std::path::{Component, Path};
 use std::process::{Output, Stdio};
 
+pub use bincode;
+pub use buffi_macro::*;
+
 const FUNCTION_PREFIX: &str = "buffi";
 
 #[derive(Debug, serde::Deserialize)]

--- a/buffi_macro/src/proc_macro.rs
+++ b/buffi_macro/src/proc_macro.rs
@@ -146,7 +146,7 @@ fn generate_exported_function<'a>(
                         std::slice::from_raw_parts(#n, #n_size)
                     }
                 };
-                let #n = bincode::serde::decode_from_slice(slice, bincode::config::legacy())?.0;
+                let #n = buffi::bincode::serde::decode_from_slice(slice, buffi::bincode::config::legacy())?.0;
             })
         } else {
             None
@@ -286,14 +286,14 @@ fn generate_exported_function<'a>(
                     Err(crate::errors::SerializableError::from(e))
                 }
             };
-            let bytes = match bincode::serde::encode_to_vec(&res, bincode::config::legacy()) {
+            let bytes = match buffi::bincode::serde::encode_to_vec(&res, buffi::bincode::config::legacy()) {
                 Ok(bytes) => {
                     bytes
                 }
                 Err(e) => {
                     #tracing_serializable_w
                     res = Err(e.into());
-                    match bincode::serde::encode_to_vec(&res, bincode::config::legacy()) {
+                    match buffi::bincode::serde::encode_to_vec(&res, buffi::bincode::config::legacy()) {
                         Ok(bytes) => {
                             bytes
                         }

--- a/example/buffi_example/Cargo.toml
+++ b/example/buffi_example/Cargo.toml
@@ -8,8 +8,7 @@ publish = false
 crate-type = ["staticlib"]
 
 [dependencies]
-buffi_macro = { path = "../../buffi_macro" }
-bincode = { version = "2.0.1", features = ["std", "serde"], default-features = false }
+buffi = { path = "../../buffi" }
 serde = { version = "1.0.214", features = ["derive"] }
 tokio = { version = "1.41.1", features = ["rt-multi-thread"] }
 cgmath = { version = "0.18.0", features = ["serde"] }

--- a/example/buffi_example/src/errors.rs
+++ b/example/buffi_example/src/errors.rs
@@ -24,16 +24,16 @@ impl From<Box<dyn Any + Send>> for SerializableError {
     }
 }
 
-impl From<bincode::error::DecodeError> for SerializableError {
-    fn from(value: bincode::error::DecodeError) -> Self {
+impl From<buffi::bincode::error::DecodeError> for SerializableError {
+    fn from(value: buffi::bincode::error::DecodeError) -> Self {
         Self {
             message: format!("Bincode Decode Error: {value}"),
         }
     }
 }
 
-impl From<bincode::error::EncodeError> for SerializableError {
-    fn from(value: bincode::error::EncodeError) -> Self {
+impl From<buffi::bincode::error::EncodeError> for SerializableError {
+    fn from(value: buffi::bincode::error::EncodeError) -> Self {
         Self {
             message: format!("Bincode Encode Error: {value}"),
         }

--- a/example/buffi_example/src/lib.rs
+++ b/example/buffi_example/src/lib.rs
@@ -11,7 +11,7 @@ pub struct TestClient {
 }
 
 /// A function that is not part of an impl block
-#[buffi_macro::exported]
+#[buffi::exported]
 pub fn free_standing_function(input: i64) -> Result<i64, String> {
     Ok(input)
 }
@@ -34,7 +34,7 @@ pub struct CustomType {
     pub itself: Option<Box<CustomType>>,
 }
 
-#[buffi_macro::exported]
+#[buffi::exported]
 impl TestClient {
     /// A function that might use context provided by a TestClient to do its thing
     pub fn client_function(&self, input: String) -> Result<String, String> {


### PR DESCRIPTION
The user now only has to add `buffi` to the dependencies and we also enforce which version of `bincode` is used for the proc-macro generated code. The error still needs to be manually derived with the buffi provided bincode. `[buffi_macro::exported]` changes to `[buffi::exported]`. `buffi_macro` is not meant to be used directly now.