### PR TITLE
Toolchain update 1.87.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "buffi"
-version = "0.3.0+rust.1.86.0"
+version = "0.3.0+rust.1.87.0"
 dependencies = [
  "bincode",
  "buffi_macro",

--- a/buffi/Cargo.toml
+++ b/buffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "buffi"
 description = "A tool to generate ergonomic, buffer-based C++ APIs."
-version = "0.3.0+rust.1.86.0"
+version = "0.3.0+rust.1.87.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/buffi"

--- a/buffi/src/lib.rs
+++ b/buffi/src/lib.rs
@@ -37,6 +37,7 @@ pub use bincode;
 pub use buffi_macro::*;
 
 const FUNCTION_PREFIX: &str = "buffi";
+const MARKER_TRAIT_JSON: &str = "#[<cfg>(not(generated_extern_impl))]";
 
 #[derive(Debug, serde::Deserialize)]
 struct WorkspaceMetadata {
@@ -1664,20 +1665,14 @@ fn generate_exported_struct(
 }
 
 fn is_relevant_impl(item: &&rustdoc_types::Item) -> bool {
-    if !item
-        .attrs
-        .contains(&String::from("#[cfg(not(generated_extern_impl))]"))
-    {
+    if !item.attrs.contains(&String::from(MARKER_TRAIT_JSON)) {
         return false;
     }
     matches!(item.inner, rustdoc_types::ItemEnum::Impl(_))
 }
 
 fn is_free_standing_impl(item: &&rustdoc_types::Item) -> bool {
-    if !item
-        .attrs
-        .contains(&String::from("#[cfg(not(generated_extern_impl))]"))
-    {
+    if !item.attrs.contains(&String::from(MARKER_TRAIT_JSON)) {
         return false;
     }
     matches!(item.inner, rustdoc_types::ItemEnum::Function(_))

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.87.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
There were slight changes to the rustdoc JSON format that we need to handle. Also I updated the Rust version in the version metadata of `buffi`. After this merge I'm going to release both packages as 0.3.0.