### PR TITLE
Add a new type to the tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,7 @@ version = "0.1.0"
 dependencies = [
  "buffi",
  "cgmath",
+ "chrono",
  "serde",
  "tokio",
 ]
@@ -119,6 +120,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a98d30140e3296250832bbaaff83b27dcd6fa3cc70fb6f1f3e5c9c0023b5317"
 dependencies = [
  "approx",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
  "num-traits",
  "serde",
 ]

--- a/example/buffi_example/Cargo.toml
+++ b/example/buffi_example/Cargo.toml
@@ -12,3 +12,4 @@ buffi = { path = "../../buffi" }
 serde = { version = "1.0.219", features = ["derive"] }
 tokio = { version = "1.45.1", features = ["rt-multi-thread"] }
 cgmath = { version = "0.18.0", features = ["serde"] }
+chrono = { version = "0.4.41", default-features = false, features = ["serde"] }

--- a/example/generate_bindings/api_config.toml
+++ b/example/generate_bindings/api_config.toml
@@ -3,5 +3,6 @@ api_lib_name = "buffi_example"
 parent_crate = "buffi_example"
 rustdoc_crates = [
     "buffi_example",
-    "cgmath"
+    "cgmath",
+    "chrono"
 ]


### PR DESCRIPTION
Added an enum with a custom "remote" type. With BuFFI it is also possible to use types from other crates in the types that are part of the FFI while simultaneously mapping them to something more fitting.

I've added a type that reflects that behavior and also improves test coverage.