### PR TITLE
Bump toolchain, update `rustdoc-types`, fix warnings, bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "buffi"
-version = "0.3.1+rust.1.88.0"
+version = "0.3.2+rust.1.89.0"
 dependencies = [
  "bincode",
  "buffi_macro",
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "buffi_macro"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -295,11 +295,12 @@ checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustdoc-types"
-version = "0.39.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b61d5673c3f4b49d35be6a58c49210596f61b8db580bc3b6d9dee5e9dc5458"
+checksum = "53175c56be456e96171b9c3efcd8e5216fbb7b40cc6355a1953090556621205b"
 dependencies = [
  "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/buffi/Cargo.toml
+++ b/buffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "buffi"
 description = "A tool to generate ergonomic, buffer-based C++ APIs."
-version = "0.3.1+rust.1.88.0"
+version = "0.3.2+rust.1.89.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/buffi"
@@ -11,7 +11,7 @@ categories = ["development-tools::ffi"]
 readme = "../README.md"
 
 [dependencies.buffi_macro]
-version = "=0.3.1"
+version = "=0.3.2"
 path = "../buffi_macro"
 
 [dependencies]
@@ -19,7 +19,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 serde-generate = { version = "0.32.0", default-features = false, features = ["cpp"] }
 serde-reflection = "0.5.0"
-rustdoc-types = "0.39.0"
+rustdoc-types = "0.53.0"
 bincode = { version = "2.0.1", features = ["std", "serde"], default-features = false }
 
 [features]

--- a/buffi_macro/Cargo.toml
+++ b/buffi_macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "buffi_macro"
 description = "A proc-macro to generate ergonomic, buffer-based C++ APIs."
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/buffi_macro"

--- a/buffi_macro/src/proc_macro.rs
+++ b/buffi_macro/src/proc_macro.rs
@@ -44,29 +44,29 @@ fn generate_exported_functions_for_impl_block(
 ) -> Result<(), syn::Error> {
     let mut syn_error: Option<syn::Error> = None;
     for item in &impl_item.items {
-        if let syn::ImplItem::Fn(m) = item {
-            if matches!(m.vis, syn::Visibility::Public(_)) {
-                let self_ty = &impl_item.self_ty;
-                let docs = m.attrs.iter().filter(|a| a.path().is_ident("doc"));
+        if let syn::ImplItem::Fn(m) = item
+            && matches!(m.vis, syn::Visibility::Public(_))
+        {
+            let self_ty = &impl_item.self_ty;
+            let docs = m.attrs.iter().filter(|a| a.path().is_ident("doc"));
 
-                let mut arg_list = Vec::new();
-                arg_list.push(quote::quote!(this_ptr: *mut #self_ty));
+            let mut arg_list = Vec::new();
+            arg_list.push(quote::quote!(this_ptr: *mut #self_ty));
 
-                match generate_exported_function(
-                    &m.sig,
-                    arg_list,
-                    exports,
-                    docs,
-                    item.span(),
-                    prefix.clone(),
-                ) {
-                    Ok(_) => (),
-                    Err(new_error) => {
-                        if let Some(e) = syn_error.as_mut() {
-                            e.combine(new_error);
-                        } else {
-                            syn_error = Some(new_error);
-                        }
+            match generate_exported_function(
+                &m.sig,
+                arg_list,
+                exports,
+                docs,
+                item.span(),
+                prefix.clone(),
+            ) {
+                Ok(_) => (),
+                Err(new_error) => {
+                    if let Some(e) = syn_error.as_mut() {
+                        e.combine(new_error);
+                    } else {
+                        syn_error = Some(new_error);
                     }
                 }
             }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.89.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
The usual :) We additionally need to review the update of the `rustdoc-types` dependency.

- [x] https://diff.weiznich.de/rustdoc-types/0.39.0/0.53.0