### PR TITLE
bump toolchain and versions for Rust 1.91.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "buffi"
-version = "0.3.3+rust.1.90.0"
+version = "0.3.4+rust.1.91.0"
 dependencies = [
  "bincode",
  "buffi_macro",
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "buffi_macro"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/buffi/Cargo.toml
+++ b/buffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "buffi"
 description = "A tool to generate ergonomic, buffer-based C++ APIs."
-version = "0.3.3+rust.1.90.0"
+version = "0.3.4+rust.1.91.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/buffi"
@@ -11,7 +11,7 @@ categories = ["development-tools::ffi"]
 readme = "../README.md"
 
 [dependencies.buffi_macro]
-version = "=0.3.3"
+version = "=0.3.4"
 path = "../buffi_macro"
 
 [dependencies]

--- a/buffi_macro/Cargo.toml
+++ b/buffi_macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "buffi_macro"
 description = "A proc-macro to generate ergonomic, buffer-based C++ APIs."
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/buffi_macro"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.90.0"
+channel = "1.91.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
No other changes need to be made