### PR TITLE
Add support for `#[serde(with = "ProxyType")]` for struct fields as well

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "buffi"
-version = "0.3.5+rust.1.92.0"
+version = "0.3.6+rust.1.92.0"
 dependencies = [
  "bincode",
  "buffi_macro",
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "buffi_macro"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/buffi/Cargo.toml
+++ b/buffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "buffi"
 description = "A tool to generate ergonomic, buffer-based C++ APIs."
-version = "0.3.5+rust.1.92.0"
+version = "0.3.6+rust.1.92.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/buffi"
@@ -11,7 +11,7 @@ categories = ["development-tools::ffi"]
 readme = "../README.md"
 
 [dependencies.buffi_macro]
-version = "=0.3.5"
+version = "=0.3.6"
 path = "../buffi_macro"
 
 [dependencies]

--- a/buffi_macro/Cargo.toml
+++ b/buffi_macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "buffi_macro"
 description = "A proc-macro to generate ergonomic, buffer-based C++ APIs."
-version = "0.3.5"
+version = "0.3.6"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/buffi_macro"

--- a/example/buffi_example/src/include/BUFFI_NAMESPACE.hpp
+++ b/example/buffi_example/src/include/BUFFI_NAMESPACE.hpp
@@ -49,6 +49,8 @@ namespace BUFFI_NAMESPACE {
         std::optional<serde::value_ptr<BUFFI_NAMESPACE::CustomType>> itself;
         /// An enum that contains a remote type that we would like to use in the API
         BUFFI_NAMESPACE::RandomEnum random_enum;
+        /// A struct field using a proxy type for (de)serialization
+        BUFFI_NAMESPACE::DateTimeHelper proxy;
 
         friend bool operator==(const CustomType&, const CustomType&);
         std::vector<uint8_t> bincodeSerialize() const;
@@ -180,6 +182,7 @@ namespace BUFFI_NAMESPACE {
         if (!(lhs.some_content == rhs.some_content)) { return false; }
         if (!(lhs.itself == rhs.itself)) { return false; }
         if (!(lhs.random_enum == rhs.random_enum)) { return false; }
+        if (!(lhs.proxy == rhs.proxy)) { return false; }
         return true;
     }
 
@@ -207,6 +210,7 @@ void serde::Serializable<BUFFI_NAMESPACE::CustomType>::serialize(const BUFFI_NAM
     serde::Serializable<decltype(obj.some_content)>::serialize(obj.some_content, serializer);
     serde::Serializable<decltype(obj.itself)>::serialize(obj.itself, serializer);
     serde::Serializable<decltype(obj.random_enum)>::serialize(obj.random_enum, serializer);
+    serde::Serializable<decltype(obj.proxy)>::serialize(obj.proxy, serializer);
     serializer.decrease_container_depth();
 }
 
@@ -218,6 +222,7 @@ BUFFI_NAMESPACE::CustomType serde::Deserializable<BUFFI_NAMESPACE::CustomType>::
     obj.some_content = serde::Deserializable<decltype(obj.some_content)>::deserialize(deserializer);
     obj.itself = serde::Deserializable<decltype(obj.itself)>::deserialize(deserializer);
     obj.random_enum = serde::Deserializable<decltype(obj.random_enum)>::deserialize(deserializer);
+    obj.proxy = serde::Deserializable<decltype(obj.proxy)>::deserialize(deserializer);
     deserializer.decrease_container_depth();
     return obj;
 }

--- a/example/buffi_example/src/lib.rs
+++ b/example/buffi_example/src/lib.rs
@@ -35,6 +35,9 @@ pub struct CustomType {
     pub itself: Option<Box<CustomType>>,
     /// An enum that contains a remote type that we would like to use in the API
     pub random_enum: RandomEnum,
+    /// A struct field using a proxy type for (de)serialization
+    #[serde(with = "crate::DateTimeHelper")]
+    pub proxy: DateTime<Utc>,
 }
 
 #[derive(Serialize)]
@@ -73,6 +76,7 @@ impl TestClient {
             some_content: content,
             itself: None,
             random_enum: RandomEnum::NoValue,
+            proxy: DateTime::from_timestamp(0, 0).expect("In bounds"),
         })
     }
 

--- a/example/generate_bindings/api_config.toml
+++ b/example/generate_bindings/api_config.toml
@@ -3,6 +3,5 @@ api_lib_name = "buffi_example"
 parent_crate = "buffi_example"
 rustdoc_crates = [
     "buffi_example",
-    "cgmath",
-    "chrono"
+    "cgmath"
 ]


### PR DESCRIPTION
This commit refactors the field generation code to be shared between enums and struct fields. This allows struct fields to also use the `#[serde(with = "ProxyType")]` pattern. It also ensures that future similar improvements will be implemented for both field types at the same time.

Finally a test case for this variant is also added.