### PR TITLE
Refactorings and improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,8 @@ dependencies = [
  "serde-generate",
  "serde-reflection",
  "serde_json",
+ "syn",
+ "url",
 ]
 
 [[package]]
@@ -147,6 +149,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,6 +178,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1a6df962265a53221f29081896c412ef325c17fa7d638cd9578febe53d3c82c"
 dependencies = [
  "typeid",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
 ]
 
 [[package]]
@@ -197,6 +219,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +341,12 @@ name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "memchr"
@@ -258,10 +388,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -397,10 +542,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"
@@ -411,6 +568,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -450,6 +618,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -534,6 +712,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,4 +809,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/README.md
+++ b/README.md
@@ -141,5 +141,5 @@ You can also have a look at the slides [here](knowledge/RustLab2024.pdf). They a
 
 ## License
 
-* Apache License, Version 2.0 (https://www.apache.org/licenses/LICENSE-2.0).
-* MIT License (https://opensource.org/licenses/MIT)
+* Apache License, Version 2.0 (<https://www.apache.org/licenses/LICENSE-2.0>).
+* MIT License (<https://opensource.org/licenses/MIT>)

--- a/buffi/Cargo.toml
+++ b/buffi/Cargo.toml
@@ -16,13 +16,17 @@ path = "../buffi_macro"
 
 [dependencies]
 serde = { version = "1.0.219", features = ["derive"] }
+syn = { version = "2.0", features = ["full", "extra-traits"] }
 serde_json = "1.0.140"
 serde-generate = { version = "0.32.0", default-features = false, features = ["cpp"] }
 serde-reflection = "0.5.0"
 rustdoc-types = "0.56.0"
 bincode = { version = "2.0.1", features = ["std", "serde"], default-features = false }
 
+url = { version = "2.5.0", optional = true }
+
 [features]
 with_c_api = ["buffi_macro/with_c_api"]
 with_tracing = ["buffi_macro/with_tracing"]
 default = ["with_c_api"]
+url2 = ["dep:url"]

--- a/buffi/src/buffi_annotation_attributes.rs
+++ b/buffi/src/buffi_annotation_attributes.rs
@@ -1,0 +1,1 @@
+../../buffi_macro/src/buffi_annotation_attributes.rs

--- a/buffi/src/traits.rs
+++ b/buffi/src/traits.rs
@@ -1,0 +1,45 @@
+use std::borrow::Cow;
+use std::path::PathBuf;
+
+/// This is a marker trait for allowed type mappings between
+/// Rust and C++ that are considered safe. It needs to be satisfied
+/// to allow `#[buffi(type = Foo)]` to work
+///
+/// It's fine to add new implementations of this trait for third
+/// party traits if you verified that bincode allows to interchange
+/// these types.
+///
+/// It's also fine to add new implementations to buffi itself if
+/// that invariant is uphold.
+///
+/// Not upholding this invariant either results in a deserialization
+/// failure or silent data corruption as bincode might interpret the
+/// provided byte array differently. As this is not a memory safety issue
+/// this is still considered to be a safe trait.
+#[diagnostic::on_unimplemented(
+    message = "cannot map `{Self}` to `{Rt}` as this is not a safe mapping",
+    note = "make sure that the bincode encoding of both types are equivalent before implementing the necessary trait"
+)]
+pub trait SafeTypeMapping<Rt> {}
+
+impl<'a> SafeTypeMapping<Cow<'a, str>> for String {}
+impl<'a> SafeTypeMapping<Option<Cow<'a, str>>> for String {}
+impl<'a> SafeTypeMapping<Vec<Cow<'a, str>>> for Vec<String> {}
+
+impl<'a, T> SafeTypeMapping<Cow<'a, [T]>> for Vec<T> where [T]: ToOwned {}
+impl<'a, T> SafeTypeMapping<Option<Cow<'a, [T]>>> for Vec<T> where [T]: ToOwned {}
+impl<'a, T> SafeTypeMapping<Vec<Cow<'a, [T]>>> for Vec<Vec<T>> where [T]: ToOwned {}
+
+impl SafeTypeMapping<PathBuf> for String {}
+impl SafeTypeMapping<Option<PathBuf>> for String {}
+impl SafeTypeMapping<Vec<PathBuf>> for Vec<String> {}
+
+// all types are compatible with themself
+impl<T> SafeTypeMapping<T> for T {}
+
+#[cfg(feature = "url2")]
+impl SafeTypeMapping<url::Url> for String {}
+#[cfg(feature = "url2")]
+impl SafeTypeMapping<Option<url::Url>> for String {}
+#[cfg(feature = "url2")]
+impl SafeTypeMapping<Vec<url::Url>> for Vec<String> {}

--- a/buffi/src/traits.rs
+++ b/buffi/src/traits.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 /// these types.
 ///
 /// It's also fine to add new implementations to buffi itself if
-/// that invariant is uphold.
+/// that invariant is upheld.
 ///
 /// Not upholding this invariant either results in a deserialization
 /// failure or silent data corruption as bincode might interpret the

--- a/buffi_macro/Cargo.toml
+++ b/buffi_macro/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 
 [dependencies]
 proc-macro2 = "1.0.95"
-syn = { version = "2.0.104", features = ["full", "extra-traits"] }
+syn = { version = "2.0.104", features = ["full", "extra-traits", "visit"] }
 quote = "1.0.40"
 
 [lib]

--- a/buffi_macro/src/annotation.rs
+++ b/buffi_macro/src/annotation.rs
@@ -1,0 +1,185 @@
+use proc_macro2::TokenStream;
+use syn::DeriveInput;
+use syn::spanned::Spanned;
+
+use crate::buffi_annotation_attributes::BuffiAnnotation;
+
+pub fn expand(item: DeriveInput) -> Result<proc_macro2::TokenStream, syn::Error> {
+    let mut verifier = VerifyAttributes {
+        errors: Vec::new(),
+        tps: Vec::new(),
+    };
+
+    syn::visit::visit_derive_input(&mut verifier, &item);
+
+    if let Some(mut err) = verifier.errors.pop() {
+        for e in verifier.errors {
+            err.combine(e);
+        }
+        Err(err)
+    } else if verifier.tps.is_empty() {
+        Ok(TokenStream::new())
+    } else {
+        let bounds = verifier.tps.into_iter().map(
+            |VerifyAttribute {
+                 span,
+                 rust_type,
+                 cpp_type,
+             }| {
+                quote::quote_spanned! {span=> #cpp_type: buffi::SafeTypeMapping<#rust_type>}
+            },
+        );
+        Ok(quote::quote! {
+            const _:() = {
+                fn __check() where #(#bounds,)* {}
+            };
+        })
+    }
+}
+
+#[derive(Debug)]
+struct VerifyAttribute {
+    span: proc_macro2::Span,
+    rust_type: syn::Type,
+    cpp_type: syn::Type,
+}
+
+#[derive(Debug)]
+struct VerifyAttributes {
+    errors: Vec<syn::Error>,
+    tps: Vec<VerifyAttribute>,
+}
+
+impl<'ast> syn::visit::Visit<'ast> for VerifyAttributes {
+    fn visit_field(&mut self, f: &'ast syn::Field) {
+        let buffi_attrs = f
+            .attrs
+            .iter()
+            .filter_map(|a| {
+                if a.path().is_ident("buffi") {
+                    Some(a.parse_args::<BuffiAnnotation>())
+                } else {
+                    None
+                }
+            })
+            .collect::<Result<Vec<_>, _>>();
+        let serde_attrs = f
+            .attrs
+            .iter()
+            .filter_map(|a| {
+                if a.path().is_ident("serde") {
+                    Some(a.parse_args::<SerdeAttr>())
+                } else {
+                    None
+                }
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap_or_default();
+        let buffi_attrs = match buffi_attrs {
+            Ok(buffi_attrs) => buffi_attrs,
+            Err(e) => {
+                self.errors.push(e);
+                Vec::new()
+            }
+        };
+
+        let has_skip = buffi_attrs
+            .iter()
+            .any(|b| matches!(b, BuffiAnnotation::Skip));
+        // if we have a buffi skip attribute we need to verify that
+        // there is also a `#[serde(default [= whatever])]` attribute
+        // otherwise this is an error
+        if has_skip
+            && !(serde_attrs.contains(&SerdeAttr::Skip)
+                && serde_attrs.contains(&SerdeAttr::Default))
+        {
+            self.errors.push(syn::Error::new(
+                f.span(),
+                "`#[buffi(skip)]` requires `#[serde(default)]` and `#[serde(skip)]` as well",
+            ));
+        }
+        if let Some(BuffiAnnotation::Tpe(buffi_type)) = buffi_attrs
+            .iter()
+            .find(|b| matches!(b, BuffiAnnotation::Tpe(_)))
+        {
+            let buffi_type = buffi_type.clone();
+            let deserialize_with = serde_attrs.iter().find_map(|s| match s {
+                SerdeAttr::DeserializeWith(p) => Some(p.clone()),
+                _ => None,
+            });
+            let serialize_with = serde_attrs.iter().find_map(|s| match s {
+                SerdeAttr::SerializeWith(s) => Some(s.clone()),
+                _ => None,
+            });
+            let mut rust_type = f.ty.clone();
+            match (serialize_with, deserialize_with) {
+                (Some(mut s), Some(mut d)) => {
+                    let _ = s.segments.pop();
+                    let last = s.segments.pop().unwrap();
+                    s.segments.push_value(last.value().clone());
+                    let _ = d.segments.pop();
+                    let last = d.segments.pop().unwrap();
+                    d.segments.push_value(last.value().clone());
+                    if s == d {
+                        rust_type = syn::Type::Path(syn::TypePath {
+                            qself: None,
+                            path: s,
+                        });
+                    } else {
+                        self.errors.push(syn::Error::new(
+                            f.ident.span(),
+                            "`#[serde(serialize_with)]` needs to refer to the same type as `#[serde(deserialize_with)]`"
+                        ));
+                    }
+                }
+                (Some(_), None) | (None, Some(_)) => {
+                    self.errors.push(syn::Error::new(
+                        f.ident.span(),
+                        "`#[buffi(type)]` requires both `#[serde(serialize_with)]` and `#[serde(deserialize_with)]`"
+                    ));
+                }
+                (None, None) => {}
+            };
+            self.tps.push(VerifyAttribute {
+                span: f.ty.span(),
+                rust_type,
+                cpp_type: syn::Type::Path(syn::TypePath {
+                    qself: None,
+                    path: buffi_type,
+                }),
+            });
+        }
+
+        syn::visit::visit_field(self, f);
+    }
+}
+
+#[derive(PartialEq)]
+enum SerdeAttr {
+    Default,
+    Skip,
+    SerializeWith(syn::Path),
+    DeserializeWith(syn::Path),
+    Unknown,
+}
+
+impl syn::parse::Parse for SerdeAttr {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let ident = input.parse::<syn::Ident>()?;
+        match ident {
+            i if i == "default" => Ok(Self::Default),
+            i if i == "skip" => Ok(Self::Skip),
+            i if i == "deserialize_with" => {
+                let _ = input.parse::<syn::Token![=]>()?;
+                let path = input.parse::<syn::LitStr>()?.parse::<syn::Path>()?;
+                Ok(Self::DeserializeWith(path))
+            }
+            i if i == "serialize_with" => {
+                let _ = input.parse::<syn::Token![=]>()?;
+                let path = input.parse::<syn::LitStr>()?.parse::<syn::Path>()?;
+                Ok(Self::SerializeWith(path))
+            }
+            _ => Ok(Self::Unknown),
+        }
+    }
+}

--- a/buffi_macro/src/buffi_annotation_attributes.rs
+++ b/buffi_macro/src/buffi_annotation_attributes.rs
@@ -1,0 +1,39 @@
+use syn::Ident;
+
+// This code is shared with buffi itself to reuse the attribute parsing
+
+#[derive(Debug)]
+#[allow( // allow and not expect as it's used in one of the locations
+    dead_code,
+    reason = "This exists for verifying that the attributes are sane"
+)]
+pub enum BuffiAnnotation {
+    Tpe(syn::Path),
+    Skip,
+}
+
+impl syn::parse::Parse for BuffiAnnotation {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        use syn::ext::IdentExt;
+
+        let ident = Ident::parse_any(input)?;
+        match &ident {
+            i if i == "type" => {
+                let _ = input.parse::<syn::Token![=]>()?;
+                let path = input.parse()?;
+                Ok(Self::Tpe(path))
+            }
+            i if i == "skip" => {
+                if input.is_empty() {
+                    Ok(Self::Skip)
+                } else {
+                    Err(syn::Error::new(input.span(), "unexpected tokens"))
+                }
+            }
+            i => Err(syn::Error::new(
+                ident.span(),
+                format!("Expected `type`, but got `{i}`"),
+            )),
+        }
+    }
+}

--- a/buffi_macro/src/lib.rs
+++ b/buffi_macro/src/lib.rs
@@ -1,5 +1,8 @@
-mod proc_macro;
 use ::proc_macro::TokenStream;
+
+mod annotation;
+mod buffi_annotation_attributes;
+mod proc_macro;
 
 const FUNCTION_PREFIX: &str = "buffi";
 
@@ -34,4 +37,13 @@ pub fn exported(_att: TokenStream, item: TokenStream) -> TokenStream {
         }
     }
     .into()
+}
+
+/// A helper derive to put annotations for the codegen on struct and enum fields
+#[proc_macro_derive(Annotation, attributes(buffi, serde))]
+pub fn annotation(item: TokenStream) -> TokenStream {
+    syn::parse(item)
+        .and_then(annotation::expand)
+        .unwrap_or_else(|e| e.to_compile_error())
+        .into()
 }

--- a/buffi_macro/src/lib.rs
+++ b/buffi_macro/src/lib.rs
@@ -40,6 +40,33 @@ pub fn exported(_att: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 /// A helper derive to put annotations for the codegen on struct and enum fields
+///
+/// Available annotations are `#[buffi(skip)]` and `#[buffi(type = SomeType]`. See below
+/// how they can be utilized.
+///
+/// Putting this derive on a type that is available via a public API allows to modify
+/// availability of fields or which specific type should be used in the FFI if type
+/// mapping is not obvious.
+///
+/// Skipping a field
+///
+/// `#[buffi(skip)]` can be used together with `#[serde(skip)]` and `#[serde(default)]`
+/// to hide fields from the FFI. In that case when this type is used in the FFI it will
+/// appear on the Rust side with a default value set for that specific field.
+///
+/// Modifying the type mapping
+///
+/// `#[buffi(type = SomeType]` can be used in cases where the Rust type is not the desired type for
+/// the FFI. It applies either where the binary representation created by serde matches
+/// another type (e.g. for `url::Url` and `String` where you have `Url` on the Rust side
+/// and want `String` in your FFI) or where the application of custom (de-)serialization
+/// is required. This second use case is connected to `#[serde(serialize_with = ...]` and
+/// `#[serde(deserialize_with = ...]`. Both annotations have to be present and have to
+/// point to functions implemented on a (helper) struct that implements buffi's `SafeTypeMapping`
+/// trait.
+///
+/// Buffi already provides some implementations of `SafeTypeMapping`. Also check if some
+/// additional implementations can be utilized via crate features (e.g. `url2`).
 #[proc_macro_derive(Annotation, attributes(buffi, serde))]
 pub fn annotation(item: TokenStream) -> TokenStream {
     syn::parse(item)

--- a/example/buffi_example/src/include/BUFFI_NAMESPACE.hpp
+++ b/example/buffi_example/src/include/BUFFI_NAMESPACE.hpp
@@ -51,6 +51,13 @@ namespace BUFFI_NAMESPACE {
         BUFFI_NAMESPACE::RandomEnum random_enum;
         /// A struct field using a proxy type for (de)serialization
         BUFFI_NAMESPACE::DateTimeHelper proxy;
+        /// Test a type overwrite
+        std::string overwrite;
+        /// using a nested type also works
+        std::vector<std::string> overwrite_2;
+        /// This field uses a custom serialization and deserialization logic
+        /// via serde
+        std::string custom;
 
         friend bool operator==(const CustomType&, const CustomType&);
         std::vector<uint8_t> bincodeSerialize() const;
@@ -183,6 +190,9 @@ namespace BUFFI_NAMESPACE {
         if (!(lhs.itself == rhs.itself)) { return false; }
         if (!(lhs.random_enum == rhs.random_enum)) { return false; }
         if (!(lhs.proxy == rhs.proxy)) { return false; }
+        if (!(lhs.overwrite == rhs.overwrite)) { return false; }
+        if (!(lhs.overwrite_2 == rhs.overwrite_2)) { return false; }
+        if (!(lhs.custom == rhs.custom)) { return false; }
         return true;
     }
 
@@ -211,6 +221,9 @@ void serde::Serializable<BUFFI_NAMESPACE::CustomType>::serialize(const BUFFI_NAM
     serde::Serializable<decltype(obj.itself)>::serialize(obj.itself, serializer);
     serde::Serializable<decltype(obj.random_enum)>::serialize(obj.random_enum, serializer);
     serde::Serializable<decltype(obj.proxy)>::serialize(obj.proxy, serializer);
+    serde::Serializable<decltype(obj.overwrite)>::serialize(obj.overwrite, serializer);
+    serde::Serializable<decltype(obj.overwrite_2)>::serialize(obj.overwrite_2, serializer);
+    serde::Serializable<decltype(obj.custom)>::serialize(obj.custom, serializer);
     serializer.decrease_container_depth();
 }
 
@@ -223,6 +236,9 @@ BUFFI_NAMESPACE::CustomType serde::Deserializable<BUFFI_NAMESPACE::CustomType>::
     obj.itself = serde::Deserializable<decltype(obj.itself)>::deserialize(deserializer);
     obj.random_enum = serde::Deserializable<decltype(obj.random_enum)>::deserialize(deserializer);
     obj.proxy = serde::Deserializable<decltype(obj.proxy)>::deserialize(deserializer);
+    obj.overwrite = serde::Deserializable<decltype(obj.overwrite)>::deserialize(deserializer);
+    obj.overwrite_2 = serde::Deserializable<decltype(obj.overwrite_2)>::deserialize(deserializer);
+    obj.custom = serde::Deserializable<decltype(obj.custom)>::deserialize(deserializer);
     deserializer.decrease_container_depth();
     return obj;
 }


### PR DESCRIPTION
* Some general refactorings to field handling of structs/enums so that it is unified on a single location and can be extended easily
* Added a new `buffi::Annotation` derive that does nothing but allows us to put attributes on struct fields
* Add a `#[buffi(type = Foo)]` attribute to allow overwriting the field type with a different type
* Added a check for `#[serde(flatten)]` as that's unsupported by bincode :(
* Some general name resolution fixes and refactorings
* Bug fixing recursive type checks being wrong sometime
* Added `#[buffi(skip)]` to skip a field
* Added a `SafeTypeMapping` trait to whitelist type mappings allowed by
  `#[buffi(type = Foo)]`
