### PR TITLE
Rust 1.94.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "buffi"
-version = "0.3.9+rust.1.93.0"
+version = "0.3.10+rust.1.94.0"
 dependencies = [
  "bincode",
  "buffi_macro",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "buffi_macro"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -440,9 +440,9 @@ checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustdoc-types"
-version = "0.57.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a32214c8a67cec971ddea507040fb3d8ac485a2cbf29ecb0a502264ab3a873"
+checksum = "23539a7b40955b4fb2635f072adb28019c2d6a9dee3708bd25ce7b357a309352"
 dependencies = [
  "serde",
  "serde_derive",

--- a/buffi/Cargo.toml
+++ b/buffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "buffi"
 description = "A tool to generate ergonomic, buffer-based C++ APIs."
-version = "0.3.9+rust.1.93.0"
+version = "0.3.10+rust.1.94.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/buffi"
@@ -11,7 +11,7 @@ categories = ["development-tools::ffi"]
 readme = "../README.md"
 
 [dependencies.buffi_macro]
-version = "=0.3.9"
+version = "=0.3.10"
 path = "../buffi_macro"
 
 [dependencies]
@@ -20,7 +20,7 @@ syn = { version = "2.0", features = ["full", "extra-traits"] }
 serde_json = "1.0.140"
 serde-generate = { version = "0.32.0", default-features = false, features = ["cpp"] }
 serde-reflection = "0.5.0"
-rustdoc-types = "0.57.0"
+rustdoc-types = "0.57.1"
 bincode = { version = "2.0.1", features = ["std", "serde"], default-features = false }
 
 url = { version = "2.5.0", optional = true }

--- a/buffi/src/lib.rs
+++ b/buffi/src/lib.rs
@@ -43,7 +43,6 @@ mod traits;
 mod buffi_annotation_attributes;
 
 const FUNCTION_PREFIX: &str = "buffi";
-const MARKER_TRAIT_STR: &str = "#[<cfg_trace>(not(generated_extern_impl))]";
 
 type FieldList = Vec<(
     String,
@@ -1937,20 +1936,24 @@ fn generate_struct_fields(
         .collect::<Vec<_>>()
 }
 
+fn has_marker_attribute(item: &rustdoc_types::Item) -> bool {
+    item.attrs.iter().any(|a| {
+        if let Attribute::Other(o) = a {
+            // other attributes now contain the span which changes from call site to call site
+            // therefore we only match the beginning
+            o.starts_with("#[attr = CfgTrace([Not(NameValue { name: \"generated_extern_impl\"")
+        } else {
+            false
+        }
+    })
+}
+
 fn is_relevant_impl(item: &&rustdoc_types::Item) -> bool {
-    let marker_attribute = Attribute::Other(MARKER_TRAIT_STR.into());
-    if !item.attrs.contains(&marker_attribute) {
-        return false;
-    }
-    matches!(item.inner, rustdoc_types::ItemEnum::Impl(_))
+    matches!(item.inner, rustdoc_types::ItemEnum::Impl(_)) && has_marker_attribute(item)
 }
 
 fn is_free_standing_impl(item: &&rustdoc_types::Item) -> bool {
-    let marker_attribute = Attribute::Other(MARKER_TRAIT_STR.into());
-    if !item.attrs.contains(&marker_attribute) {
-        return false;
-    }
-    matches!(item.inner, rustdoc_types::ItemEnum::Function(_))
+    matches!(item.inner, rustdoc_types::ItemEnum::Function(_)) && has_marker_attribute(item)
 }
 
 fn to_c_type(tpe: &rustdoc_types::Type) -> String {

--- a/buffi_macro/Cargo.toml
+++ b/buffi_macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "buffi_macro"
 description = "A proc-macro to generate ergonomic, buffer-based C++ APIs."
-version = "0.3.9"
+version = "0.3.10"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/buffi_macro"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.93.0"
+channel = "1.94.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
Rust 1.94 changed the encoding of some attributes. They now include a span like this:

```
 Other(
        "#[attr = CfgTrace([Not(NameValue { name: \"generated_extern_impl\", value: None, span: example/buffi_example/src/lib.rs:87:1: 87:19 (#37) }, example/buffi_example/src/lib.rs:87:1: 87:19 (#37))])]",
    ),
``` 

So our old matching code did not work anymore. This commit fixes the detection of exported items, so this BuFFI now works with Rust 1.94.