### PR TITLE
Symlink license files into individual workspace crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "buffi"
-version = "0.3.11+rust.1.95.0"
+version = "0.3.12+rust.1.95.0"
 dependencies = [
  "bincode",
  "buffi_macro",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "buffi_macro"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/buffi/Cargo.toml
+++ b/buffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "buffi"
 description = "A tool to generate ergonomic, buffer-based C++ APIs."
-version = "0.3.11+rust.1.95.0"
+version = "0.3.12+rust.1.95.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/buffi"
@@ -11,7 +11,7 @@ categories = ["development-tools::ffi"]
 readme = "../README.md"
 
 [dependencies.buffi_macro]
-version = "=0.3.11"
+version = "=0.3.12"
 path = "../buffi_macro"
 
 [dependencies]

--- a/buffi/LICENSE-APACHE2
+++ b/buffi/LICENSE-APACHE2
@@ -1,0 +1,1 @@
+../LICENSE-APACHE2

--- a/buffi/LICENSE-MIT
+++ b/buffi/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/buffi_macro/Cargo.toml
+++ b/buffi_macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "buffi_macro"
 description = "A proc-macro to generate ergonomic, buffer-based C++ APIs."
-version = "0.3.11"
+version = "0.3.12"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/buffi_macro"

--- a/buffi_macro/LICENSE-APACHE2
+++ b/buffi_macro/LICENSE-APACHE2
@@ -1,0 +1,1 @@
+../LICENSE-APACHE2

--- a/buffi_macro/LICENSE-MIT
+++ b/buffi_macro/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
... and bump version number for new release.

We only have the actual license files in the workspace root and the license SPDX definition in the individual crate toml files, but we are missing the license files in the workspace crates when they are published. Since there is no official "good" way to do this yet, I have symlinked the license files into `buffi` and `buffi_macro`. This should not be an issue as long as these crates are not published from a Windows machine I think.

I would publish a new version after this has been merged.