### PR TITLE
Add a reoccurring job to run our test on nightly every day

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,9 @@ jobs:
     name: Check rustfmt style && run clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.1
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@1.85.0
         with:
           components: clippy, rustfmt
@@ -28,7 +30,9 @@ jobs:
     name: Generate and check bindings of the basic example
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.85.0
+      - uses: actions/checkout@v6.0.1
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@1.95.0
       - name: Run test
         run: cargo test -p tests

--- a/.github/workflows/nightly_ci.yml
+++ b/.github/workflows/nightly_ci.yml
@@ -1,0 +1,19 @@
+on:
+  workflow_dispatch:
+  # run at 5:30 on every day
+  schedule:
+    - cron: '30 5 * * *'
+
+name: BuFFI CI (test on nightly)
+
+jobs:
+  test_on_nightly:
+    name: Run the test on the latest nightly
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.1
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@nightly
+      - name: Run test on nightly
+        run: cargo +nightly test -p tests


### PR DESCRIPTION
And bumb the rust version for the PR related job.

This makes sense to catch breaking changes in Rust earlier to not have to resort to reverting changes in Rust itself.