### PR TITLE
Add `buffi` as a cfg flag when running `cargo doc`

### DIFF
--- a/buffi/src/lib.rs
+++ b/buffi/src/lib.rs
@@ -416,7 +416,10 @@ pub fn generate_docs(
         .arg("doc")
         .args(args)
         .env("RUSTC_BOOTSTRAP", bootstrap_crates)
-        .env("RUSTDOCFLAGS", "-Z unstable-options --output-format json ")
+        .env(
+            "RUSTDOCFLAGS",
+            "--cfg buffi -Z unstable-options --output-format json ",
+        )
         .env("CARGO_TARGET_DIR", &target_directory)
         .stderr(Stdio::inherit())
         .stdout(Stdio::inherit());


### PR DESCRIPTION
This currently comes in handy to workaround an issue with Rust 1.96.0, but might also proof useful in the future.